### PR TITLE
FRML-39 Add Wideband Support and Refactor Architecture

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,13 +1,12 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: Python CI
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/src/frdc/conf.py
+++ b/src/frdc/conf.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).parents[2]
@@ -6,33 +7,26 @@ SECRETS_DIR = ROOT_DIR / '.secrets'
 GCS_PROJECT_ID = 'frmodel'
 GCS_BUCKET_NAME = 'frdc-scan'
 
-
 # These are sorted by wavelength
-# TODO: Is this a bit ugly? I'm not sure if there's a better way to do this.
-class Band:
-    WIDE_BLUE = 0
-    WIDE_GREEN = 1
-    WIDE_RED = 2
-    BLUE = 3
-    GREEN = 4
-    RED = 5
-    RED_EDGE = 6
-    NIR = 7
+DEFAULT_BAND_CONFIG = {
+    'WR': ('*result.tif', lambda x: x[..., 0]),
+    'WG': ('*result.tif', lambda x: x[..., 1]),
+    'WB': ('*result.tif', lambda x: x[..., 2]),
+    'NR': ('result_Red.tif', lambda x: x),
+    'NG': ('result_Green.tif', lambda x: x),
+    'NB': ('result_Blue.tif', lambda x: x),
+    'Red Edge': ('result_RedEdge.tif', lambda x: x),
+    'NIR': ('result_NIR.tif', lambda x: x),
+}
 
-    FILE_NAME_GLOBS = (
-        '*result.tif',
-        'result_Blue.tif',
-        'result_Green.tif',
-        'result_Red.tif',
-        'result_RedEdge.tif',
-        'result_NIR.tif'
-    )
+DEFAULT_BAND_SCALED_CONFIG = {
+    'WR': ('*result.tif', lambda x: x[..., 0] / 2 ** 8),
+    'WG': ('*result.tif', lambda x: x[..., 1] / 2 ** 8),
+    'WB': ('*result.tif', lambda x: x[..., 2] / 2 ** 8),
+    'NR': ('result_Red.tif', lambda x: x / 2 ** 14),
+    'NG': ('result_Green.tif', lambda x: x / 2 ** 14),
+    'NB': ('result_Blue.tif', lambda x: x / 2 ** 14),
+    'Red Edge': ('result_RedEdge.tif', lambda x: x / 2 ** 14),
+    'NIR': ('result_NIR.tif', lambda x: x / 2 ** 14),
+}
 
-    WIDE_BLUE_MAX = 2 ** 16
-    WIDE_GREEN_MAX = 2 ** 16
-    WIDE_RED_MAX = 2 ** 16
-    BLUE_MAX = 2 ** 14
-    GREEN_MAX = 2 ** 14
-    RED_MAX = 2 ** 14
-    RED_EDGE_MAX = 2 ** 14
-    NIR_MAX = 2 ** 14

--- a/src/frdc/conf.py
+++ b/src/frdc/conf.py
@@ -7,25 +7,24 @@ SECRETS_DIR = ROOT_DIR / '.secrets'
 GCS_PROJECT_ID = 'frmodel'
 GCS_BUCKET_NAME = 'frdc-scan'
 
-# These are sorted by wavelength
 BAND_CONFIG = OrderedDict({
-    'WR': ('*result.tif', lambda x: x[..., 0:1]),
-    'WG': ('*result.tif', lambda x: x[..., 1:2]),
     'WB': ('*result.tif', lambda x: x[..., 2:3]),
-    'NR': ('result_Red.tif', lambda x: x),
-    'NG': ('result_Green.tif', lambda x: x),
+    'WG': ('*result.tif', lambda x: x[..., 1:2]),
+    'WR': ('*result.tif', lambda x: x[..., 0:1]),
     'NB': ('result_Blue.tif', lambda x: x),
+    'NG': ('result_Green.tif', lambda x: x),
+    'NR': ('result_Red.tif', lambda x: x),
     'RE': ('result_RedEdge.tif', lambda x: x),
     'NIR': ('result_NIR.tif', lambda x: x),
 })
 
-# DEFAULT_BAND_SCALED_CONFIG = OrderedDict({
-#     'WR': ('*result.tif', lambda x: x[..., 0:1] / 2 ** 8),
-#     'WG': ('*result.tif', lambda x: x[..., 1:2] / 2 ** 8),
-#     'WB': ('*result.tif', lambda x: x[..., 2:3] / 2 ** 8),
-#     'NR': ('result_Red.tif', lambda x: x / 2 ** 14),
-#     'NG': ('result_Green.tif', lambda x: x / 2 ** 14),
-#     'NB': ('result_Blue.tif', lambda x: x / 2 ** 14),
-#     'RE': ('result_RedEdge.tif', lambda x: x / 2 ** 14),
-#     'NIR': ('result_NIR.tif', lambda x: x / 2 ** 14),
-# })
+BAND_MAX_CONFIG: dict[str, tuple[int, int]] = {
+    'WR': (0, 2 ** 8),
+    'WG': (0, 2 ** 8),
+    'WB': (0, 2 ** 8),
+    'NR': (0, 2 ** 14),
+    'NG': (0, 2 ** 14),
+    'NB': (0, 2 ** 14),
+    'RE': (0, 2 ** 14),
+    'NIR': (0, 2 ** 14),
+}

--- a/src/frdc/conf.py
+++ b/src/frdc/conf.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from collections import OrderedDict
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).parents[2]
@@ -8,25 +8,24 @@ GCS_PROJECT_ID = 'frmodel'
 GCS_BUCKET_NAME = 'frdc-scan'
 
 # These are sorted by wavelength
-DEFAULT_BAND_CONFIG = {
-    'WR': ('*result.tif', lambda x: x[..., 0]),
-    'WG': ('*result.tif', lambda x: x[..., 1]),
-    'WB': ('*result.tif', lambda x: x[..., 2]),
+BAND_CONFIG = OrderedDict({
+    'WR': ('*result.tif', lambda x: x[..., 0:1]),
+    'WG': ('*result.tif', lambda x: x[..., 1:2]),
+    'WB': ('*result.tif', lambda x: x[..., 2:3]),
     'NR': ('result_Red.tif', lambda x: x),
     'NG': ('result_Green.tif', lambda x: x),
     'NB': ('result_Blue.tif', lambda x: x),
-    'Red Edge': ('result_RedEdge.tif', lambda x: x),
+    'RE': ('result_RedEdge.tif', lambda x: x),
     'NIR': ('result_NIR.tif', lambda x: x),
-}
+})
 
-DEFAULT_BAND_SCALED_CONFIG = {
-    'WR': ('*result.tif', lambda x: x[..., 0] / 2 ** 8),
-    'WG': ('*result.tif', lambda x: x[..., 1] / 2 ** 8),
-    'WB': ('*result.tif', lambda x: x[..., 2] / 2 ** 8),
-    'NR': ('result_Red.tif', lambda x: x / 2 ** 14),
-    'NG': ('result_Green.tif', lambda x: x / 2 ** 14),
-    'NB': ('result_Blue.tif', lambda x: x / 2 ** 14),
-    'Red Edge': ('result_RedEdge.tif', lambda x: x / 2 ** 14),
-    'NIR': ('result_NIR.tif', lambda x: x / 2 ** 14),
-}
-
+# DEFAULT_BAND_SCALED_CONFIG = OrderedDict({
+#     'WR': ('*result.tif', lambda x: x[..., 0:1] / 2 ** 8),
+#     'WG': ('*result.tif', lambda x: x[..., 1:2] / 2 ** 8),
+#     'WB': ('*result.tif', lambda x: x[..., 2:3] / 2 ** 8),
+#     'NR': ('result_Red.tif', lambda x: x / 2 ** 14),
+#     'NG': ('result_Green.tif', lambda x: x / 2 ** 14),
+#     'NB': ('result_Blue.tif', lambda x: x / 2 ** 14),
+#     'RE': ('result_RedEdge.tif', lambda x: x / 2 ** 14),
+#     'NIR': ('result_NIR.tif', lambda x: x / 2 ** 14),
+# })

--- a/src/frdc/conf.py
+++ b/src/frdc/conf.py
@@ -10,13 +10,17 @@ GCS_BUCKET_NAME = 'frdc-scan'
 # These are sorted by wavelength
 # TODO: Is this a bit ugly? I'm not sure if there's a better way to do this.
 class Band:
-    BLUE = 0
-    GREEN = 1
-    RED = 2
-    RED_EDGE = 3
-    NIR = 4
+    WIDE_BLUE = 0
+    WIDE_GREEN = 1
+    WIDE_RED = 2
+    BLUE = 3
+    GREEN = 4
+    RED = 5
+    RED_EDGE = 6
+    NIR = 7
 
-    FILE_NAMES = (
+    FILE_NAME_GLOBS = (
+        '*result.tif',
         'result_Blue.tif',
         'result_Green.tif',
         'result_Red.tif',
@@ -24,6 +28,9 @@ class Band:
         'result_NIR.tif'
     )
 
+    WIDE_BLUE_MAX = 2 ** 16
+    WIDE_GREEN_MAX = 2 ** 16
+    WIDE_RED_MAX = 2 ** 16
     BLUE_MAX = 2 ** 14
     GREEN_MAX = 2 ** 14
     RED_MAX = 2 ** 14

--- a/src/frdc/load/dataset.py
+++ b/src/frdc/load/dataset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
@@ -182,7 +183,13 @@ class FRDCDataset:
         d = {}
         fp_cache = {}
 
-        config = {k: v for k, v in BAND_CONFIG.items() if k in bands}
+        try:
+            config = OrderedDict({k: BAND_CONFIG[k] for k in bands})
+        except KeyError:
+            raise KeyError(
+                f"Invalid band name. Valid band names are {BAND_CONFIG.keys()}"
+            )
+
         for name, (glob, transform) in config.items():
             fp = self.dl.download_file(path_glob=self.dataset_dir / glob)
 

--- a/src/frdc/load/dataset.py
+++ b/src/frdc/load/dataset.py
@@ -80,9 +80,10 @@ class FRDCDownloader:
             If our file in GCS is in
             gs://frdc-scan/casuarina/20220418/183deg/result_Blue.tif
             then we can download it with:
-            # >>> download_file(
-            # >>>     path=Path("casuarina/20220418/183deg/result_Blue.tif")
-            # >>> )
+
+            >>> download_file(
+            >>>     path=Path("casuarina/20220418/183deg/result_Blue.tif")
+            >>> )
 
         Raises:
             ValueError: If there are multiple blobs that match the path_glob.
@@ -162,20 +163,15 @@ class FRDCDataset:
             This is used to preserve the bands separately as keys and values.
 
         Args:
-            bands: The bands to get, as a list of band names.
-                See BAND_CONFIG for the list of band names.
+            bands: The bands to get, e.g. ['WB', 'WG', 'WR']. By default, this
+                get all bands in BAND_CONFIG.
 
         Examples:
-            # >>> get_bands({
-            # >>>     'WR': ('*result.tif', lambda x: x[..., 0:1]),
-            # >>>     'WG': ('*result.tif', lambda x: x[..., 1:2]),
-            # >>>     ...
-            # >>> })
+            >>> get_ar_bands_as_dict(['WB', 'WG', 'WR']])
 
-            This example will return {'WR': np.ndarray, 'WG': np.ndarray, ...}
-            where np.ndarray is the image array.
+            Returns
 
-            The transform function above is used to slice the image array.
+            >>> {'WB': np.ndarray, 'WG': np.ndarray, 'WR': np.ndarray}
 
         Returns:
             A dictionary of (KeyName, image) pairs.
@@ -211,10 +207,18 @@ class FRDCDataset:
         """ Gets the bands as a numpy array, and the band order as a list.
 
         Notes:
-            This is a wrapper around get_bands, which concatenates the bands.
+            This is a wrapper around get_bands, concatenating the bands.
 
         Args:
-            bands: The bands to get, as a list of band names.
+            bands: The bands to get, e.g. ['WB', 'WG', 'WR']. By default, this
+                get all bands in BAND_CONFIG.
+
+        Examples
+            >>> get_ar_bands(['WB', 'WG', 'WR'])
+
+            Returns
+
+            >>> (np.ndarray, ['WB', 'WG', 'WR'])
 
         Returns:
             A tuple of (ar, band_order), where ar is a numpy array of shape

--- a/src/frdc/preprocess/__init__.py
+++ b/src/frdc/preprocess/__init__.py
@@ -1,6 +1,9 @@
-from .extract_segments import (extract_segments_from_labels, extract_segments_from_bounds,
+from .extract_segments import (extract_segments_from_labels,
+                               extract_segments_from_bounds,
                                remove_small_segments_from_labels)
-from .preprocess import compute_labels
+from .preprocess import (scale_0_1_per_band, threshold_binary_mask,
+                         binary_watershed)
 
-__all__ = ['compute_labels', 'extract_segments_from_labels', 'extract_segments_from_bounds',
-           'remove_small_segments_from_labels']
+__all__ = ['extract_segments_from_labels', 'extract_segments_from_bounds',
+           'remove_small_segments_from_labels', 'scale_0_1_per_band',
+           'threshold_binary_mask', 'binary_watershed']

--- a/src/frdc/preprocess/preprocess.py
+++ b/src/frdc/preprocess/preprocess.py
@@ -21,16 +21,28 @@ def scale_0_1_per_band(ar: np.ndarray) -> np.ndarray:
     return np.stack(ar_bands, axis=-1)
 
 
-# def scale_static_per_band(ar: np.ndarray) -> np.ndarray:
-#     """ This scales statically, by their defined maximum   """
-#     ar = ar.copy()
-#     ar[:, :, Band.BLUE] /= Band.BLUE_MAX
-#     ar[:, :, Band.GREEN] /= Band.GREEN_MAX
-#     ar[:, :, Band.RED] /= Band.RED_MAX
-#     ar[:, :, Band.RED_EDGE] /= Band.RED_EDGE_MAX
-#     ar[:, :, Band.NIR] /= Band.NIR_MAX
-#
-#     return ar
+def scale_static_per_band(
+        ar: np.ndarray,
+        order: list[str],
+        bounds_config: dict[str, tuple[int, int]] = BAND_MAX_CONFIG
+) -> np.ndarray:
+    """ This scales statically per band, using the bounds_config.
+
+    Args:
+        ar: NDArray of shape (H, W, C), where C is the number of bands.
+        order: The order of the bands.
+        bounds_config: The bounds config, see BAND_MAX_CONFIG for an example.
+
+    Returns:
+        The scaled array.
+    """
+    ar = ar.copy()
+
+    for e, band in enumerate(order):
+        ar_min, ar_max = bounds_config[band]
+        ar[..., e] = (ar[..., e] - ar_min) / (ar_max - ar_min)
+
+    return ar
 
 
 def threshold_binary_mask(ar: np.ndarray,

--- a/src/frdc/preprocess/preprocess.py
+++ b/src/frdc/preprocess/preprocess.py
@@ -1,8 +1,59 @@
+import warnings
+
 import numpy as np
 from scipy import ndimage
 from scipy.ndimage import distance_transform_edt
 from skimage.feature import peak_local_max
+from skimage.morphology import remove_small_objects, remove_small_holes
 from skimage.segmentation import watershed
+
+from frdc.conf import BAND_MAX_CONFIG
+
+
+def compute_labels(
+        ar: np.ndarray,
+        nir_band_ix: int = -1,
+        nir_threshold_value=90 / 256,
+        min_crown_size=1000,
+        min_crown_hole=1000,
+        connectivity=2,
+        peaks_footprint=200,
+        watershed_compactness=0
+) -> np.ndarray:
+    """ Automatically segments crowns from an NDArray with a series of image processing operations.
+
+    Args:
+        ar: NDArray of shape (H, W, C), where C is the number of bands, C is sorted by Band.FILE_NAMES.
+        nir_threshold_value: Threshold value for the NIR band.
+        min_crown_size: Minimum crown size in pixels.
+        min_crown_hole: Minimum crown hole size in pixels.
+        connectivity: Connectivity for morphological operations.
+        peaks_footprint: Footprint for peak_local_max.
+        watershed_compactness: Compactness for watershed.
+
+    Returns:
+        A tuple of (background, crowns), background is the background image and crowns is a list of np.ndarray crowns.
+        Background is of shape (H, W, C), where C is the number of bands, C is sorted by Band.FILE_NAMES.
+        Crowns is a list of np.ndarray crowns, each crown is of shape (H, W, C).
+    """
+    # Raise deprecation worning
+    warnings.warn(
+        "This function is to be deprecated. use functions separately instead "
+        "for more control over the parameters. This function assumes the NIR "
+        "band is the last band.",
+        DeprecationWarning
+    )
+
+    ar = scale_0_1_per_band(ar)
+    # ar = scale_static_per_band(ar)
+    ar_mask = threshold_binary_mask(ar, -1, nir_threshold_value)
+    ar_mask = remove_small_objects(ar_mask, min_size=min_crown_size,
+                                   connectivity=connectivity)
+    ar_mask = remove_small_holes(ar_mask, area_threshold=min_crown_hole,
+                                 connectivity=connectivity)
+    ar_labels = binary_watershed(ar_mask, peaks_footprint,
+                                 watershed_compactness)
+    return ar_labels
 
 
 def scale_0_1_per_band(ar: np.ndarray) -> np.ndarray:

--- a/src/frdc/preprocess/preprocess.py
+++ b/src/frdc/preprocess/preprocess.py
@@ -20,10 +20,12 @@ def compute_labels(
         peaks_footprint=200,
         watershed_compactness=0
 ) -> np.ndarray:
-    """ Automatically segments crowns from an NDArray with a series of image processing operations.
+    """ Automatically segments crowns from an NDArray with a series of image
+        processing operations.
 
     Args:
-        ar: NDArray of shape (H, W, C), where C is the number of bands, C is sorted by Band.FILE_NAMES.
+        ar: NDArray of shape (H, W, C), where C is the number of bands
+        nir_band_ix: Index of NIR Band.
         nir_threshold_value: Threshold value for the NIR band.
         min_crown_size: Minimum crown size in pixels.
         min_crown_hole: Minimum crown hole size in pixels.
@@ -32,8 +34,9 @@ def compute_labels(
         watershed_compactness: Compactness for watershed.
 
     Returns:
-        A tuple of (background, crowns), background is the background image and crowns is a list of np.ndarray crowns.
-        Background is of shape (H, W, C), where C is the number of bands, C is sorted by Band.FILE_NAMES.
+        A tuple of (background, crowns), background is the background image and
+        crowns is a list of np.ndarray crowns.
+        Background is of shape (H, W, C), where C is the number of bands
         Crowns is a list of np.ndarray crowns, each crown is of shape (H, W, C).
     """
     # Raise deprecation worning
@@ -45,8 +48,7 @@ def compute_labels(
     )
 
     ar = scale_0_1_per_band(ar)
-    # ar = scale_static_per_band(ar)
-    ar_mask = threshold_binary_mask(ar, -1, nir_threshold_value)
+    ar_mask = threshold_binary_mask(ar, nir_band_ix, nir_threshold_value)
     ar_mask = remove_small_objects(ar_mask, min_size=min_crown_size,
                                    connectivity=connectivity)
     ar_mask = remove_small_holes(ar_mask, area_threshold=min_crown_hole,
@@ -83,6 +85,23 @@ def scale_static_per_band(
         ar: NDArray of shape (H, W, C), where C is the number of bands.
         order: The order of the bands.
         bounds_config: The bounds config, see BAND_MAX_CONFIG for an example.
+
+    Examples:
+        If you've retrieved the data from `get_ar_bands`, then you can use the
+        order returned from that function. This is the recommended way to use
+        this function.
+
+        >>> ar, order = get_ar_bands()
+        >>> scale_static_per_band(ar, order)
+
+        If you need more control over the order, you can specify it manually.
+        Given that you have an ar of shape (H, W, 3) with order
+        ['WB', 'WG', 'WR']
+
+        >>> scale_static_per_band(
+        >>>     ar, ['WB', 'WG', 'WR']
+        >>>     bounds_config={'WB': (0, 256), 'WG': (0, 256), 'WR': (0, 256)}
+        >>> )
 
     Returns:
         The scaled array.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from frdc.load import FRDCDownloader, FRDCDataset
@@ -11,3 +12,23 @@ def dl() -> FRDCDownloader:
 @pytest.fixture(scope='session')
 def ds() -> FRDCDataset:
     return FRDCDataset._load_debug_dataset()
+
+
+@pytest.fixture(scope='session')
+def ar_and_order(ds) -> tuple[np.ndarray, list[str]]:
+    return ds.get_ar_bands()
+
+
+@pytest.fixture(scope='session')
+def debug_file_path():
+    return 'DEBUG/0/result_Red.tif'
+
+
+@pytest.fixture(scope='session')
+def ar(ar_and_order):
+    return ar_and_order[0]
+
+
+@pytest.fixture(scope='session')
+def order(ar_and_order):
+    return ar_and_order[1]

--- a/tests/integration_tests/test_pipeline.py
+++ b/tests/integration_tests/test_pipeline.py
@@ -13,14 +13,14 @@ from frdc.train import dummy_train
 def test_auto_segmentation_pipeline(ds):
     """ Tests the use case where we just want to automatically segment the image. """
 
-    ar = ds.get_ar_bands()
+    ar = ds.get_bands()
     ar_labels = compute_labels(ar)
     ar_segments = extract_segments_from_labels(ar, ar_labels)
 
 
 def test_manual_segmentation_pipeline(ds):
     """ Test the use case where we manually segment the image, then train a model on it. """
-    ar = ds.get_ar_bands()
+    ar = ds.get_bands()
     ar = np.nan_to_num(ar)
     bounds, labels = ds.get_bounds_and_labels()
     segments = extract_segments_from_bounds(ar, bounds, cropped=False)
@@ -44,7 +44,7 @@ def test_manual_segmentation_pipeline(ds):
 
 def test_unlabelled_prediction(ds):
     """ Test the use case where we have unlabelled data, and we want to predict the labels. """
-    ar = ds.get_ar_bands()
+    ar = ds.get_bands()
     bounds, labels = ds.get_bounds_and_labels()
 
     # TODO: We need to revisit how "unlabelled" is defined.
@@ -68,7 +68,7 @@ def test_consistency_sampling(ds):
     6) Sample the most inconsistent segments
 
     """
-    ar = ds.get_ar_bands()
+    ar = ds.get_bands()
     bounds, labels = ds.get_bounds_and_labels()
 
     # TODO: We need to revisit how "unlabelled" is defined.

--- a/tests/unit_tests/load/test_frdc_dataset.py
+++ b/tests/unit_tests/load/test_frdc_dataset.py
@@ -4,13 +4,13 @@ from frdc.conf import Band
 
 
 def test_download_file_exist_ok(dl):
-    fp = dl.download_file(path=f'DEBUG/0/{Band.FILE_NAMES[0]}')
+    fp = dl.download_file(path_glob=f'DEBUG/0/{Band.FILE_NAME_GLOBS[0]}')
     assert fp.exists()
 
 
 def test_download_file_exist_not_ok(dl):
     with pytest.raises(FileExistsError):
-        dl.download_file(path=f'DEBUG/0/{Band.FILE_NAMES[0]}', local_exists_ok=False)
+        dl.download_file(path_glob=f'DEBUG/0/{Band.FILE_NAME_GLOBS[0]}', local_exists_ok=False)
 
 
 def test_list_datasets(dl):

--- a/tests/unit_tests/load/test_frdc_dataset.py
+++ b/tests/unit_tests/load/test_frdc_dataset.py
@@ -1,18 +1,17 @@
-import pytest
-
-from frdc.conf import Band
-
-
-def test_download_file_exist_ok(dl):
-    fp = dl.download_file(path_glob=f'DEBUG/0/{Band.FILE_NAME_GLOBS[0]}')
-    assert fp.exists()
+from frdc.conf import BAND_CONFIG
+from frdc.utils import Rect
 
 
-def test_download_file_exist_not_ok(dl):
-    with pytest.raises(FileExistsError):
-        dl.download_file(path_glob=f'DEBUG/0/{Band.FILE_NAME_GLOBS[0]}', local_exists_ok=False)
+def test_get_ar_bands_as_dict(ds):
+    d = ds.get_ar_bands_as_dict(BAND_CONFIG)
+    assert set(d.keys()) == set(d.keys())
 
 
-def test_list_datasets(dl):
-    df = dl.list_gcs_datasets()
-    assert len(df) > 0
+def test_get_ar_bands(ar, order):
+    assert ar.shape[-1] == len(order)
+
+
+def test_get_bounds(ds):
+    bounds, labels = ds.get_bounds_and_labels()
+    assert all([isinstance(b, Rect) for b in bounds])
+    assert len(bounds) == len(labels)

--- a/tests/unit_tests/load/test_frdc_dataset.py
+++ b/tests/unit_tests/load/test_frdc_dataset.py
@@ -7,8 +7,16 @@ def test_get_ar_bands_as_dict(ds):
     assert set(d.keys()) == set(d.keys())
 
 
-def test_get_ar_bands(ar, order):
-    assert ar.shape[-1] == len(order)
+def test_get_ar_bands(ds):
+    ar, order = ds.get_ar_bands()
+    assert ar.shape[-1] == len(BAND_CONFIG)
+    assert order == list(BAND_CONFIG.keys())
+
+
+def test_get_ar_bands_ordering(ds):
+    ar, order = ds.get_ar_bands(['WB', 'WG'])
+    assert ar.shape[-1] == 2
+    assert order == ['WB', 'WG']
 
 
 def test_get_bounds(ds):

--- a/tests/unit_tests/load/test_frdc_downloader.py
+++ b/tests/unit_tests/load/test_frdc_downloader.py
@@ -1,29 +1,19 @@
 import pytest
 
-from frdc.conf import Band
 
-
-def test_download_file_exist_ok(dl):
-    fp = dl.download_file(path_glob=f'DEBUG/0/{Band.FILE_NAME_GLOBS[0]}')
-    assert fp.exists()
-
-
-def test_download_file_exist_not_ok(dl):
+def test_download_file_exist_ok(dl, debug_file_path):
+    fp = dl.download_file(path_glob=debug_file_path, local_exists_ok=True)
+    assert fp.exists(), "File doesn't exist after download."
     with pytest.raises(FileExistsError):
-        dl.download_file(path_glob=f'DEBUG/0/{Band.FILE_NAME_GLOBS[0]}', local_exists_ok=False)
+        dl.download_file(path_glob=debug_file_path, local_exists_ok=False)
+
+
+def test_download_multiple_files(dl):
+    """ Test that download_file shouldn't support multiple files. """
+    with pytest.raises(ValueError):
+        dl.download_file(path_glob='**/*.tif')
 
 
 def test_list_datasets(dl):
     df = dl.list_gcs_datasets()
     assert len(df) > 0
-
-
-def test_get_ar_bands(ds):
-    ar_bands = ds.get_bands()
-    assert ar_bands.shape[-1] == len(Band.FILE_NAME_GLOBS)
-
-
-def test_get_bounds(ds):
-    bounds, labels = ds.get_bounds_and_labels()
-    assert all([len(b) == 4 for b in bounds])
-    assert len(bounds) == len(labels)

--- a/tests/unit_tests/load/test_frdc_downloader.py
+++ b/tests/unit_tests/load/test_frdc_downloader.py
@@ -4,13 +4,13 @@ from frdc.conf import Band
 
 
 def test_download_file_exist_ok(dl):
-    fp = dl.download_file(path=f'DEBUG/0/{Band.FILE_NAMES[0]}')
+    fp = dl.download_file(path_glob=f'DEBUG/0/{Band.FILE_NAME_GLOBS[0]}')
     assert fp.exists()
 
 
 def test_download_file_exist_not_ok(dl):
     with pytest.raises(FileExistsError):
-        dl.download_file(path=f'DEBUG/0/{Band.FILE_NAMES[0]}', local_exists_ok=False)
+        dl.download_file(path_glob=f'DEBUG/0/{Band.FILE_NAME_GLOBS[0]}', local_exists_ok=False)
 
 
 def test_list_datasets(dl):
@@ -19,8 +19,8 @@ def test_list_datasets(dl):
 
 
 def test_get_ar_bands(ds):
-    ar_bands = ds.get_ar_bands()
-    assert ar_bands.shape[-1] == len(Band.FILE_NAMES)
+    ar_bands = ds.get_bands()
+    assert ar_bands.shape[-1] == len(Band.FILE_NAME_GLOBS)
 
 
 def test_get_bounds(ds):

--- a/tests/unit_tests/preprocess/test_extract_segments.py
+++ b/tests/unit_tests/preprocess/test_extract_segments.py
@@ -65,27 +65,27 @@ def test_remove_small_segments_from_labels():
 
 def test_extract_segments_from_bounds_cropped(ds):
     bounds, labels = ds.get_bounds_and_labels()
-    segments = extract_segments_from_bounds(ar := ds.get_ar_bands(), bounds,
+    segments = extract_segments_from_bounds(ar := ds.get_bands(), bounds,
                                             cropped=True)
     assert any(segment.shape != ar.shape for segment in segments)
 
 
 def test_extract_segments_from_bounds_no_crop(ds):
     bounds, labels = ds.get_bounds_and_labels()
-    segments = extract_segments_from_bounds(ar := ds.get_ar_bands(), bounds,
+    segments = extract_segments_from_bounds(ar := ds.get_bands(), bounds,
                                             cropped=False)
     assert all(segment.shape == ar.shape for segment in segments)
 
 
 def test_extract_segments_from_labels_cropped(ds):
-    ar_labels = compute_labels(ds.get_ar_bands(), peaks_footprint=10)
-    segments = extract_segments_from_labels(ar := ds.get_ar_bands(), ar_labels,
+    ar_labels = compute_labels(ds.get_bands(), peaks_footprint=10)
+    segments = extract_segments_from_labels(ar := ds.get_bands(), ar_labels,
                                             cropped=True)
     assert any(segment.shape != ar.shape for segment in segments)
 
 
 def test_extract_segments_from_labels_no_crop(ds):
-    ar_labels = compute_labels(ds.get_ar_bands(), peaks_footprint=10)
-    segments = extract_segments_from_labels(ar := ds.get_ar_bands(), ar_labels,
+    ar_labels = compute_labels(ds.get_bands(), peaks_footprint=10)
+    segments = extract_segments_from_labels(ar := ds.get_bands(), ar_labels,
                                             cropped=False)
     assert all(segment.shape == ar.shape for segment in segments)

--- a/tests/unit_tests/preprocess/test_extract_segments.py
+++ b/tests/unit_tests/preprocess/test_extract_segments.py
@@ -15,9 +15,8 @@ Thus, our test is:
 """
 import numpy as np
 
-from frdc.preprocess import (extract_segments_from_bounds,
-                             extract_segments_from_labels, compute_labels,
-                             remove_small_segments_from_labels)
+from frdc.preprocess import *
+from utils import get_labels
 
 
 def test_remove_small_segments_from_labels():
@@ -63,29 +62,25 @@ def test_remove_small_segments_from_labels():
     test_unique_labels({0}, min_height=4, min_width=4)
 
 
-def test_extract_segments_from_bounds_cropped(ds):
+def test_extract_segments_from_bounds_cropped(ds, ar):
     bounds, labels = ds.get_bounds_and_labels()
-    segments = extract_segments_from_bounds(ar := ds.get_bands(), bounds,
-                                            cropped=True)
+    segments = extract_segments_from_bounds(ar, bounds, cropped=True)
     assert any(segment.shape != ar.shape for segment in segments)
 
 
-def test_extract_segments_from_bounds_no_crop(ds):
+def test_extract_segments_from_bounds_no_crop(ds, ar):
     bounds, labels = ds.get_bounds_and_labels()
-    segments = extract_segments_from_bounds(ar := ds.get_bands(), bounds,
-                                            cropped=False)
+    segments = extract_segments_from_bounds(ar, bounds, cropped=False)
     assert all(segment.shape == ar.shape for segment in segments)
 
 
-def test_extract_segments_from_labels_cropped(ds):
-    ar_labels = compute_labels(ds.get_bands(), peaks_footprint=10)
-    segments = extract_segments_from_labels(ar := ds.get_bands(), ar_labels,
-                                            cropped=True)
+def test_extract_segments_from_labels_cropped(ar, order):
+    ar_labels = get_labels(ar, order)
+    segments = extract_segments_from_labels(ar, ar_labels, cropped=True)
     assert any(segment.shape != ar.shape for segment in segments)
 
 
-def test_extract_segments_from_labels_no_crop(ds):
-    ar_labels = compute_labels(ds.get_bands(), peaks_footprint=10)
-    segments = extract_segments_from_labels(ar := ds.get_bands(), ar_labels,
-                                            cropped=False)
+def test_extract_segments_from_labels_no_crop(ar, order):
+    ar_labels = get_labels(ar, order)
+    segments = extract_segments_from_labels(ar, ar_labels, cropped=False)
     assert all(segment.shape == ar.shape for segment in segments)

--- a/tests/unit_tests/preprocess/test_preprocess.py
+++ b/tests/unit_tests/preprocess/test_preprocess.py
@@ -38,7 +38,7 @@ def test_extract_segments():
          [2, 3]]
     )
     ar_segments = extract_segments_from_labels(ar_source, ar_label, cropped=False)
-    assert np.isclose(ar_segments[0], np.array([[[10], [np.nan]], [[np.nan], [np.nan]]]), equal_nan=True).all()
-    assert np.isclose(ar_segments[1], np.array([[[np.nan], [20]], [[np.nan], [np.nan]]]), equal_nan=True).all()
-    assert np.isclose(ar_segments[2], np.array([[[np.nan], [np.nan]], [[30], [np.nan]]]), equal_nan=True).all()
-    assert np.isclose(ar_segments[3], np.array([[[np.nan], [np.nan]], [[np.nan], [40]]]), equal_nan=True).all()
+    assert np.isclose(ar_segments[0],np.array([[[10], [np.nan]], [[np.nan], [np.nan]]]), equal_nan=True).all()
+    assert np.isclose(ar_segments[1],np.array([[[np.nan], [20]], [[np.nan], [np.nan]]]), equal_nan=True).all()
+    assert np.isclose(ar_segments[2],np.array([[[np.nan], [np.nan]], [[30], [np.nan]]]), equal_nan=True).all()
+    assert np.isclose(ar_segments[3],np.array([[[np.nan], [np.nan]], [[np.nan], [40]]]), equal_nan=True).all()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+from skimage.morphology import remove_small_objects, remove_small_holes
+
+from frdc.preprocess import *
+
+
+def get_labels(ar, order):
+    ar = scale_0_1_per_band(ar)
+    ar_mask = threshold_binary_mask(ar, order.index('NIR'))
+    ar_mask = remove_small_objects(ar_mask, min_size=100, connectivity=2)
+    ar_mask = remove_small_holes(ar_mask, area_threshold=100, connectivity=2)
+    ar_labels = binary_watershed(ar_mask)
+    return ar_labels


### PR DESCRIPTION
# Major Changes
Was supposed to be a quick effort to add wideband support, however, it's more difficult than expected because `result.tif` has 3 channels instead of the assumed 1.

In some effort to reduce future compatibility issues (e.g. new bands) I've overhauled some architecture, however, users are only to note the following code breaking changes:

- `get_ar_bands` now returns `ar, order`, where
  - `ar` is the usual **NumPy** array
  - `order` is the `list[str]` order of the channel dimension of the NumPy array.
- `get_ar_bands` now supports explicitly specifying the bands to use.
  - `get_ar_bands(['WR','WB','NIR'])` will thus retrieve only those bands, and concatenated in that order.

## Additional Notes
- Added `get_ar_bands_by_dict` for an alternative approach to retrieving bands, this is the same as `get_ar_bands`, except it doesn't perform concatenation.
- Add **Deprecation Warning** on composite function `compute_labels`. Recommend to list out all operations as the function is not easily code mutable.
- Changed `scale_static_per_band` to take in a `bounds_config` for more flexible scaling
- Made CI trigger on every PR

