### PR TITLE
FRML-97 Add pg_dump script for Label Studio Annotation Backup

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,3 @@
 label-studio/
 !label-studio/docker-compose.yml
+!label-studio/dump.sh

--- a/src/frdc/conf.py
+++ b/src/frdc/conf.py
@@ -77,3 +77,15 @@ except requests.exceptions.ConnectionError:
         f"LABEL_STUDIO_CLIENT will be None."
     )
     LABEL_STUDIO_CLIENT = None
+
+try:
+    logger.info("Attempting to Get Label Studio Project...")
+    LABEL_STUDIO_CLIENT.get_project(1)
+except requests.exceptions.HTTPError:
+    logger.warning(
+        f"Could not get main annotation project. "
+        f"Pulling annotations may not work. "
+        f"It's possible that your API Key is incorrect, "
+        f"or somehow your .netrc is preventing you from "
+        f"accessing the project. "
+    )

--- a/src/label-studio/docker-compose.yml
+++ b/src/label-studio/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - ${POSTGRES_DATA_DIR:-./postgres-data}:/var/lib/postgresql/data
+      - ${POSTGRES_DATA_DIR:-./postgres-backups}:/var/lib/postgresql/backups
       - ./deploy/pgsql/certs:/var/lib/postgresql/certs:ro
     networks:
       - label-studio

--- a/src/label-studio/dump.sh
+++ b/src/label-studio/dump.sh
@@ -1,0 +1,16 @@
+echo "Creating backups directory..."
+docker exec label-studio-db-1 sh -c "if [ ! -d \"/var/lib/postgresql/backups/\" ]; then mkdir -p \"/var/lib/postgresql/backups/\"; fi"
+
+echo "Checking if label-studio-db-1 is running..."
+docker exec label-studio-db-1 sh -c "pg_isready -U postgres"
+
+if [ $? -ne 0 ]; then
+    echo "label-studio-db-1 is not running. Exiting..."
+    exit 1
+fi
+
+echo "Dumping database... to /var/lib/postgresql/backups/"
+docker exec label-studio-db-1 sh -c "pg_dump -Fc -U postgres -d postgres -f \"/var/lib/postgresql/backups/$(date +'%d-%m-%Y_%HH%MM%SS').backup\""
+
+echo "Dumping database in SQL format... to /var/lib/postgresql/backups/"
+docker exec label-studio-db-1 sh -c "pg_dump -U postgres -d postgres -f \"/var/lib/postgresql/backups/$(date +'%d-%m-%Y_%HH%MM%SS').sql\""


### PR DESCRIPTION
# Major Changes
- Add `pg_dump` script and mount backup dir to host