### PR TITLE
FRML-119 Make Standard Scaler fit on segments only

### DIFF
--- a/src/frdc/models/inceptionv3.py
+++ b/src/frdc/models/inceptionv3.py
@@ -25,11 +25,18 @@ class InceptionV3MixMatchModule(MixMatchModule):
         x_scaler: StandardScaler,
         y_encoder: OrdinalEncoder,
         ema_lr: float = 0.001,
+        imagenet_scaling: bool = False,
     ):
         """Initialize the InceptionV3 model.
 
         Args:
-            n_classes: The number of output classes
+            in_channels: The number of input channels.
+            n_classes: The number of classes.
+            lr: The learning rate.
+            x_scaler: The X input StandardScaler.
+            y_encoder: The Y input OrdinalEncoder.
+            ema_lr: The learning rate for the EMA model.
+            imagenet_scaling: Whether to use the adapted ImageNet scaling.
 
         Notes:
             - Min input size: 299 x 299.
@@ -129,7 +136,7 @@ class InceptionV3MixMatchModule(MixMatchModule):
         return inception
 
     @staticmethod
-    def transform_input(x: torch.Tensor) -> torch.Tensor:
+    def imagenet_scaling(x: torch.Tensor) -> torch.Tensor:
         """Perform adapted ImageNet normalization on the input tensor.
 
         See Also:
@@ -181,7 +188,9 @@ class InceptionV3MixMatchModule(MixMatchModule):
                 f"Got: {x.shape[2]} x {x.shape[3]}."
             )
 
-        x = self.transform_input(x)
+        if self.imagenet_scaling:
+            x = self.imagenet_scaling(x)
+
         # During training, the auxiliary outputs are used for auxiliary loss,
         # but during testing, only the main output is used.
         if self.training:

--- a/src/frdc/models/inceptionv3.py
+++ b/src/frdc/models/inceptionv3.py
@@ -81,8 +81,8 @@ class InceptionV3MixMatchModule(MixMatchModule):
         # The problem is that the deep copy runs even before the module is
         # initialized, which means ema_model is empty.
         ema_model = deepcopy(self)
-        for param in ema_model.parameters():
-            param.detach_()
+        # for param in ema_model.parameters():
+        #     param.detach_()
 
         self._ema_model = ema_model
         self.ema_updater = EMA(model=self, ema_model=self.ema_model)

--- a/src/frdc/models/inceptionv3.py
+++ b/src/frdc/models/inceptionv3.py
@@ -53,6 +53,7 @@ class InceptionV3MixMatchModule(MixMatchModule):
             sharpen_temp=0.5,
             mix_beta_alpha=0.75,
         )
+        self.imagenet_scaling = imagenet_scaling
 
         self.inception = inception_v3(
             weights=Inception_V3_Weights.IMAGENET1K_V1,
@@ -136,7 +137,7 @@ class InceptionV3MixMatchModule(MixMatchModule):
         return inception
 
     @staticmethod
-    def imagenet_scaling(x: torch.Tensor) -> torch.Tensor:
+    def _imagenet_scaling(x: torch.Tensor) -> torch.Tensor:
         """Perform adapted ImageNet normalization on the input tensor.
 
         See Also:
@@ -189,7 +190,7 @@ class InceptionV3MixMatchModule(MixMatchModule):
             )
 
         if self.imagenet_scaling:
-            x = self.imagenet_scaling(x)
+            x = self._imagenet_scaling(x)
 
         # During training, the auxiliary outputs are used for auxiliary loss,
         # but during testing, only the main output is used.

--- a/src/frdc/train/frdc_datamodule.py
+++ b/src/frdc/train/frdc_datamodule.py
@@ -53,7 +53,6 @@ class FRDCDataModule(LightningDataModule):
         batch_size: The batch size to use for the dataloaders.
         train_iters: The number of iterations to run for the labelled training
             dataset.
-        val_iters: The number of iterations to run for the validation dataset.
 
     """
 
@@ -62,7 +61,6 @@ class FRDCDataModule(LightningDataModule):
     train_unl_ds: FRDCDataset | FRDCUnlabelledDataset | None = None
     batch_size: int = 4
     train_iters: int = 100
-    val_iters: int = 100
     sampling_strategy: Literal["stratified", "random"] = "stratified"
 
     def __post_init__(self):

--- a/src/frdc/train/mixmatch_module.py
+++ b/src/frdc/train/mixmatch_module.py
@@ -153,8 +153,6 @@ class MixMatchModule(LightningModule):
 
         self.log("train/x_lbl_mean", x_lbl.mean())
         self.log("train/x_lbl_stdev", x_lbl.std())
-        self.log("train/x0_unl_mean", x_unls[0].mean())
-        self.log("train/x0_unl_stdev", x_unls[0].std())
 
         wandb.log({"train/x_lbl": self.wandb_hist(y_lbl, self.n_classes)})
         y_lbl_ohe = one_hot(y_lbl.long(), num_classes=self.n_classes)
@@ -163,6 +161,8 @@ class MixMatchModule(LightningModule):
         # Otherwise, we are just using supervised learning.
         if x_unls:
             # This route implies that we are using SSL
+            self.log("train/x0_unl_mean", x_unls[0].mean())
+            self.log("train/x0_unl_stdev", x_unls[0].std())
             with torch.no_grad():
                 y_unl = self.guess_labels(x_unls=x_unls)
                 y_unl = self.sharpen(y_unl, self.sharpen_temp)

--- a/src/frdc/train/mixmatch_module.py
+++ b/src/frdc/train/mixmatch_module.py
@@ -51,7 +51,6 @@ class MixMatchModule(LightningModule):
         self.sharpen_temp = sharpen_temp
         self.mix_beta_alpha = mix_beta_alpha
         self.save_hyperparameters()
-        self.lbl_logger = WandBLabelLogger()
 
     @property
     @abstractmethod
@@ -151,14 +150,13 @@ class MixMatchModule(LightningModule):
 
     def training_step(self, batch, batch_idx):
         (x_lbl, y_lbl), x_unls = batch
-        self.lbl_logger(
-            self.logger.experiment,
-            "Input Y Label",
-            y_lbl,
-            flush_every=10,
-            num_bins=self.n_classes,
-        )
 
+        self.log("train/x_lbl_mean", x_lbl.mean())
+        self.log("train/x_lbl_stdev", x_lbl.std())
+        self.log("train/x0_unl_mean", x_unls[0].mean())
+        self.log("train/x0_unl_stdev", x_unls[0].std())
+
+        wandb.log({"train/x_lbl": self.wandb_hist(y_lbl, self.n_classes)})
         y_lbl_ohe = one_hot(y_lbl.long(), num_classes=self.n_classes)
 
         # If x_unls is Truthy, then we are using MixMatch.
@@ -183,34 +181,34 @@ class MixMatchModule(LightningModule):
             y_mix_unl = y_mix[batch_size:]
 
             loss_lbl = self.loss_lbl(y_mix_lbl_pred, y_mix_lbl)
-            self.lbl_logger(
-                self.logger.experiment,
-                "Labelled Y Pred",
-                torch.argmax(y_mix_lbl_pred, dim=1),
-                flush_every=10,
-                num_bins=self.n_classes,
-            )
             loss_unl = self.loss_unl(y_mix_unl_pred, y_mix_unl)
-            self.lbl_logger(
-                self.logger.experiment,
-                "Unlabelled Y Pred",
-                torch.argmax(y_mix_unl_pred, dim=1),
-                flush_every=10,
-                num_bins=self.n_classes,
+            wandb.log(
+                {
+                    "train/y_lbl_pred": self.wandb_hist(
+                        torch.argmax(y_mix_lbl_pred, dim=1), self.n_classes
+                    )
+                }
+            )
+            wandb.log(
+                {
+                    "train/y_unl_pred": self.wandb_hist(
+                        torch.argmax(y_mix_unl_pred, dim=1), self.n_classes
+                    )
+                }
             )
             loss_unl_scale = self.loss_unl_scaler(progress=self.progress)
 
             loss = loss_lbl + loss_unl * loss_unl_scale
 
-            self.log("loss_unl_scale", loss_unl_scale, prog_bar=True)
-            self.log("train_loss_lbl", loss_lbl)
-            self.log("train_loss_unl", loss_unl)
+            self.log("train/loss_unl_scale", loss_unl_scale, prog_bar=True)
+            self.log("train/ce_loss_lbl", loss_lbl)
+            self.log("train/mse_loss_unl", loss_unl)
         else:
             # This route implies that we are just using supervised learning
             y_pred = self(x_lbl)
             loss = self.loss_lbl(y_pred, y_lbl_ohe.float())
 
-        self.log("train_loss", loss)
+        self.log("train/loss", loss)
 
         # Evaluate train accuracy
         with torch.no_grad():
@@ -218,7 +216,7 @@ class MixMatchModule(LightningModule):
             acc = accuracy(
                 y_pred, y_lbl, task="multiclass", num_classes=y_pred.shape[1]
             )
-            self.log("train_acc", acc, prog_bar=True)
+            self.log("train/acc", acc, prog_bar=True)
         return loss
 
     # PyTorch Lightning doesn't automatically no_grads the EMA step.
@@ -227,30 +225,31 @@ class MixMatchModule(LightningModule):
     def on_after_backward(self) -> None:
         self.update_ema()
 
+    @staticmethod
+    def wandb_hist(x: torch.Tensor, num_bins: int) -> wandb.Histogram:
+        return wandb.Histogram(
+            torch.flatten(x).detach().cpu().tolist(),
+            num_bins=num_bins,
+        )
+
     def validation_step(self, batch, batch_idx):
         x, y = batch
-        self.lbl_logger(
-            self.logger.experiment,
-            "Val Input Y Label",
-            y,
-            flush_every=1,
-            num_bins=self.n_classes,
-        )
+        wandb.log({"val/y_lbl": self.wandb_hist(y, self.n_classes)})
         y_pred = self.ema_model(x)
-        self.lbl_logger(
-            self.logger.experiment,
-            "Val Pred Y Label",
-            torch.argmax(y_pred, dim=1),
-            flush_every=1,
-            num_bins=self.n_classes,
+        wandb.log(
+            {
+                "val/y_lbl_pred": self.wandb_hist(
+                    torch.argmax(y_pred, dim=1), self.n_classes
+                )
+            }
         )
         loss = F.cross_entropy(y_pred, y.long())
 
         acc = accuracy(
             y_pred, y, task="multiclass", num_classes=y_pred.shape[1]
         )
-        self.log("val_loss", loss)
-        self.log("val_acc", acc, prog_bar=True)
+        self.log("val/ce_loss", loss)
+        self.log("val/acc", acc, prog_bar=True)
         return loss
 
     def test_step(self, batch, batch_idx):
@@ -261,8 +260,8 @@ class MixMatchModule(LightningModule):
         acc = accuracy(
             y_pred, y, task="multiclass", num_classes=y_pred.shape[1]
         )
-        self.log("test_loss", loss)
-        self.log("test_acc", acc, prog_bar=True)
+        self.log("test/ce_loss", loss)
+        self.log("test/acc", acc, prog_bar=True)
         return loss
 
     def predict_step(self, batch, *args, **kwargs) -> Any:
@@ -305,7 +304,7 @@ class MixMatchModule(LightningModule):
 
             # Move Channel back to the second dimension
             # B x H x W x C -> B x C x H x W
-            return (
+            return torch.nan_to_num(
                 torch.from_numpy(x_ss.reshape(b, h, w, c))
                 .permute(0, 3, 1, 2)
                 .float()
@@ -335,46 +334,11 @@ class MixMatchModule(LightningModule):
         nan = ~torch.isnan(y_trans)
         x_lab_trans = x_lab_trans[nan]
         x_unl_trans = [x[nan] for x in x_unl_trans]
+        x_lab_trans = torch.nan_to_num(x_lab_trans)
+        x_unl_trans = [torch.nan_to_num(x) for x in x_unl_trans]
         y_trans = y_trans[nan]
 
         if self.training:
             return (x_lab_trans, y_trans.long()), x_unl_trans
         else:
             return x_lab_trans, y_trans.long()
-
-
-class WandBLabelLogger(dict):
-    """Logger to log y labels to WandB"""
-
-    def __call__(
-        self,
-        logger: wandb.sdk.wandb_run.Run,
-        key: str,
-        value: torch.Tensor,
-        num_bins: int,
-        flush_every: int = 10,
-    ):
-        """Log the labels to WandB
-
-        Args:
-            logger: The W&B logger. Accessible through `self.logger.experiment`
-            key: The key to log the labels under.
-            value: The labels to log.
-            flush_every: How often to flush the labels to WandB.
-
-        """
-        if key not in self.keys():
-            self[key] = [value]
-        else:
-            self[key].append(value)
-
-        if len(self[key]) % flush_every == 0:
-            logger.log(
-                {
-                    key: wandb.Histogram(
-                        torch.flatten(value).detach().cpu().tolist(),
-                        num_bins=num_bins,
-                    )
-                }
-            )
-            self[key] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import numpy as np
 import pytest
+import wandb
 
 from frdc.load.dataset import FRDCDataset
 from frdc.load.preset import FRDCDatasetPreset
+
+wandb.init(mode="disabled")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration_tests/test_pipeline.py
+++ b/tests/integration_tests/test_pipeline.py
@@ -42,5 +42,5 @@ def test_manual_segmentation_pipeline(ds):
     trainer = pl.Trainer(fast_dev_run=True)
     trainer.fit(m, datamodule=dm)
 
-    val_loss = trainer.validate(m, datamodule=dm)[0]["val_loss"]
+    val_loss = trainer.validate(m, datamodule=dm)[0]["val/ce_loss"]
     logging.debug(f"Validation score: {val_loss:.2%}")

--- a/tests/model_tests/chestnut_dec_may/train.py
+++ b/tests/model_tests/chestnut_dec_may/train.py
@@ -56,7 +56,6 @@ def main(
     batch_size=32,
     epochs=10,
     train_iters=25,
-    val_iters=15,
     lr=1e-3,
     wandb_name="chestnut_dec_may",
     wandb_project="frdc",
@@ -145,7 +144,6 @@ if __name__ == "__main__":
     BATCH_SIZE = 32
     EPOCHS = 50
     TRAIN_ITERS = 25
-    VAL_ITERS = 15
     LR = 1e-3
 
     torch.set_float32_matmul_precision("high")
@@ -153,7 +151,6 @@ if __name__ == "__main__":
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
         train_iters=TRAIN_ITERS,
-        val_iters=VAL_ITERS,
         lr=LR,
         wandb_name="Try with Inception Unfrozen & Random Erasing",
         wandb_project="frdc-dev",


### PR DESCRIPTION
# Major Changes
- Make Standard Scaler fit on the train segments only instead of the whole image, which produces a more accurate range
- Improve formatting of logged variable names. Use `<category>/<varname>` to better format in WandB
- Expose the option to use implicit static ImageNet Scaling in model
- Unfreeze InceptionV3

# Minor Changes
- Remove unused `val_iters` args
