### PR TITLE
FRML-128 Add circumvention for multiple annots & bad labs

### DIFF
--- a/src/frdc/load/label_studio.py
+++ b/src/frdc/load/label_studio.py
@@ -16,35 +16,42 @@ class Task(dict):
     def get_bounds_and_labels(self) -> tuple[list[tuple[int, int]], list[str]]:
         bounds = []
         labels = []
-        for ann_ix, ann in enumerate(self["annotations"]):
-            results = ann["result"]
-            for r_ix, r in enumerate(results):
-                r: dict
 
-                # We flatten the value dict into the result dict
-                v = r.pop("value")
-                r = {**r, **v}
+        # for ann_ix, ann in enumerate(self["annotations"]):
 
-                # Points are in percentage, we need to convert them to pixels
-                r["points"] = [
-                    (
-                        int(x * r["original_width"] / 100),
-                        int(y * r["original_height"] / 100),
-                    )
-                    for x, y in r["points"]
-                ]
+        ann = self["annotations"][0]
+        results = ann["result"]
+        for r_ix, r in enumerate(results):
+            r: dict
 
-                # Only take the first label as this is not a multi-label task
-                r["label"] = r.pop("polygonlabels")[0]
-                if not r["closed"]:
-                    logger.warning(
-                        f"Label for {r['label']} @ {r['points']} not closed. "
-                        f"Skipping"
-                    )
-                    continue
+            # See Issue FRML-78: Somehow some labels are actually just metadata
+            if r["from_name"] != "label":
+                continue
 
-                bounds.append(r["points"])
-                labels.append(r["label"])
+            # We flatten the value dict into the result dict
+            v = r.pop("value")
+            r = {**r, **v}
+
+            # Points are in percentage, we need to convert them to pixels
+            r["points"] = [
+                (
+                    int(x * r["original_width"] / 100),
+                    int(y * r["original_height"] / 100),
+                )
+                for x, y in r["points"]
+            ]
+
+            # Only take the first label as this is not a multi-label task
+            r["label"] = r.pop("polygonlabels")[0]
+            if not r["closed"]:
+                logger.warning(
+                    f"Label for {r['label']} @ {r['points']} not closed. "
+                    f"Skipping"
+                )
+                continue
+
+            bounds.append(r["points"])
+            labels.append(r["label"])
 
         return bounds, labels
 


### PR DESCRIPTION
See FRML-128 issue for more details on this fix

- Fixes issue where some labels may not be segmentations at all
- Bandaid problem where multiple annotations may be present