### PR TITLE
FRML-75 Implement partial save/loading of Models

### DIFF
--- a/src/frdc/models/utils.py
+++ b/src/frdc/models/utils.py
@@ -5,19 +5,29 @@ def on_save_checkpoint(
     self,
     checkpoint: Dict[str, Any],
     saved_module_prefixes: Sequence[str] = ("fc.",),
+    saved_module_suffixes: Sequence[str] = (
+        "running_mean",
+        "running_var",
+        "num_batches_tracked",
+    ),
 ) -> None:
     """Saving only the classifier if frozen.
 
     Notes:
+        This is used for the on_save_checkpoint method of the LightningModule.
         This only reduces the size of the checkpoint, however, loading
         will still require the full model.
 
-        This reduces the model size from 200MB to 300kB.
+        This usually reduces the model size by 99.9%, so it's worth it.
+
+        By default, this will save the classifier and the BatchNorm running
+        statistics.
 
     Args:
         self: Not used, but kept for consistency with on_load_checkpoint.
         checkpoint: The checkpoint to save.
-        saved_module_prefixes: The prefixes to save.
+        saved_module_prefixes: The prefixes of the modules to save.
+        saved_module_suffixes: The suffixes of the modules to save.
     """
 
     if checkpoint["hyper_parameters"]["frozen"]:
@@ -25,7 +35,10 @@ def on_save_checkpoint(
         checkpoint["state_dict"] = {
             k: v
             for k, v in checkpoint["state_dict"].items()
-            if k.startswith(saved_module_prefixes)
+            if (
+                k.startswith(saved_module_prefixes)
+                or k.endswith(saved_module_suffixes)
+            )
         }
 
 
@@ -33,6 +46,7 @@ def on_load_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
     """Loading only the classifier if frozen
 
     Notes:
+        This is used for the on_load_checkpoint method of the LightningModule.
         This still supports unfrozen models.
     """
 

--- a/src/frdc/models/utils.py
+++ b/src/frdc/models/utils.py
@@ -1,0 +1,40 @@
+from typing import Dict, Any, Sequence
+
+
+def on_save_checkpoint(
+    self,
+    checkpoint: Dict[str, Any],
+    saved_module_prefixes: Sequence[str] = ("fc.",),
+) -> None:
+    """Saving only the classifier if frozen.
+
+    Notes:
+        This only reduces the size of the checkpoint, however, loading
+        will still require the full model.
+
+        This reduces the model size from 200MB to 300kB.
+
+    Args:
+        self: Not used, but kept for consistency with on_load_checkpoint.
+        checkpoint: The checkpoint to save.
+        saved_module_prefixes: The prefixes to save.
+    """
+
+    if checkpoint["hyper_parameters"]["frozen"]:
+        # Keep only the classifier
+        checkpoint["state_dict"] = {
+            k: v
+            for k, v in checkpoint["state_dict"].items()
+            if k.startswith(saved_module_prefixes)
+        }
+
+
+def on_load_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
+    """Loading only the classifier if frozen
+
+    Notes:
+        This still supports unfrozen models.
+    """
+
+    self.load_state_dict(checkpoint["state_dict"], strict=False)
+    checkpoint["state_dict"] = self.state_dict()

--- a/src/frdc/train/fixmatch_module.py
+++ b/src/frdc/train/fixmatch_module.py
@@ -13,7 +13,6 @@ from torchmetrics.functional import accuracy
 from frdc.train.utils import (
     wandb_hist,
     preprocess,
-    mix_up,
 )
 
 
@@ -149,6 +148,7 @@ class FixMatchModule(LightningModule):
         acc = accuracy(
             y_pred, y, task="multiclass", num_classes=y_pred.shape[1]
         )
+
         self.log("val/ce_loss", loss)
         self.log("val/acc", acc, prog_bar=True)
         return loss

--- a/tests/integration_tests/test_pipeline.py
+++ b/tests/integration_tests/test_pipeline.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 import torch
 from sklearn.preprocessing import StandardScaler, OrdinalEncoder
-from torch import nn
 
 from frdc.models.efficientnetb1 import (
     EfficientNetB1MixMatchModule,
@@ -82,3 +81,15 @@ def test_manual_segmentation_pipeline(model_fn, ds):
             any_diff = True
 
     assert not any_diff, "Loaded model parameters differ from original"
+
+    # If this step fails, it's likely something "hidden", like the BatchNorm
+    # running statistics that differs.
+    val_load_loss = trainer.validate(m_load, datamodule=dm)[0]["val/ce_loss"]
+    assert val_loss == val_load_loss, "Validation loss differs after loading"
+
+    # Note:
+    #   This test doesn't check for all modules to be the same.
+    #   E.g. achieved via hash comparison.
+    #   This is because BatchNorm usually keeps running statistics
+    #   and reloading the model will reset them.
+    #   We don't necessarily need to

--- a/tests/model_tests/chestnut_dec_may/train_fixmatch.py
+++ b/tests/model_tests/chestnut_dec_may/train_fixmatch.py
@@ -44,9 +44,16 @@ def main(
     train_iters=25,
     unlabelled_factor=2,
     lr=1e-3,
+    accelerator="gpu",
+    wandb_active: bool = True,
     wandb_name="chestnut_dec_may",
     wandb_project="frdc",
 ):
+    if not wandb_active:
+        import os
+
+        os.environ["WANDB_MODE"] = "offline"
+
     # Prepare the dataset
     im_size = 255
     train_lab_ds = ds.chestnut_20201218(transform=weak_aug(im_size))
@@ -68,7 +75,7 @@ def main(
     trainer = pl.Trainer(
         max_epochs=epochs,
         deterministic=True,
-        accelerator="gpu",
+        accelerator=accelerator,
         log_every_n_steps=4,
         callbacks=[
             # Stop training if the validation loss doesn't improve for 4 epochs


### PR DESCRIPTION
# Major Changes
Implemented `on_save_checkpoint` `on_load_checkpoint` such that saving the model only saves non-frozen parameters, significantly reducing the required disk space to hold the relevant parameters.

Through a quick analysis, this reduces the necessary size to save by 99.9%, which is significant for large models like EfficientNetB1.