### PR TITLE
FRML-145 Update evaluation dataset to use all 8 orients

### DIFF
--- a/tests/model_tests/chestnut_dec_may/train_fixmatch.py
+++ b/tests/model_tests/chestnut_dec_may/train_fixmatch.py
@@ -24,7 +24,7 @@ from frdc.train.frdc_datamodule import FRDCDataModule
 from frdc.utils.training import predict, plot_confusion_matrix
 from model_tests.utils import (
     val_preprocess,
-    FRDCDatasetFlipped,
+    FRDCDatasetStaticEval,
     n_weak_strong_aug,
     get_y_encoder,
     get_x_scaler,
@@ -116,7 +116,7 @@ def main(
         )
 
     y_true, y_pred = predict(
-        ds=FRDCDatasetFlipped(
+        ds=FRDCDatasetStaticEval(
             "chestnut_nature_park",
             "20210510",
             "90deg43m85pct255deg",

--- a/tests/model_tests/chestnut_dec_may/train_mixmatch.py
+++ b/tests/model_tests/chestnut_dec_may/train_mixmatch.py
@@ -23,7 +23,7 @@ from frdc.train.frdc_datamodule import FRDCDataModule
 from frdc.utils.training import predict, plot_confusion_matrix
 from model_tests.utils import (
     val_preprocess,
-    FRDCDatasetFlipped,
+    FRDCDatasetStaticEval,
     n_strong_aug,
     strong_aug,
     get_y_encoder,
@@ -107,7 +107,7 @@ def main(
         )
 
     y_true, y_pred = predict(
-        ds=FRDCDatasetFlipped(
+        ds=FRDCDatasetStaticEval(
             "chestnut_nature_park",
             "20210510",
             "90deg43m85pct255deg",


### PR DESCRIPTION
# Major Changes
Update the evaluation dataset (FRDCDatasetFlipped, now FRDCDatasetStaticEval)
to use all 8 orientations:
```
1.       As-is
2, 3, 4. Rotated 90, 180, 270 degrees
5.       Horizontally flipped
6, 7, 8. Horizontally flipped and rotated 90, 180, 270 degrees
```