### PR TITLE
FRML-142 Make preprocessing signature the same for Train & Eval

### DIFF
--- a/src/frdc/train/fixmatch_module.py
+++ b/src/frdc/train/fixmatch_module.py
@@ -199,8 +199,8 @@ class FixMatchModule(LightningModule):
             x_unl = None
 
         return preprocess(
-            x_lab=x_lbl,
-            y_lab=y_lbl,
+            x_lbl=x_lbl,
+            y_lbl=y_lbl,
             x_scaler=self.x_scaler,
             y_encoder=self.y_encoder,
             x_unl=x_unl,

--- a/src/frdc/train/frdc_datamodule.py
+++ b/src/frdc/train/frdc_datamodule.py
@@ -66,6 +66,8 @@ class FRDCDataModule(LightningDataModule):
     def __post_init__(self):
         super().__init__()
 
+        # This provides a failsafe interface if somehow someone used the
+        # labelled dataset as the unlabelled dataset.
         if isinstance(self.train_unl_ds, FRDCDataset):
             self.train_unl_ds.__class__ = FRDCUnlabelledDataset
 

--- a/src/frdc/train/mixmatch_module.py
+++ b/src/frdc/train/mixmatch_module.py
@@ -250,23 +250,16 @@ class MixMatchModule(LightningModule):
             want to export the model alongside the transformations.
         """
 
-        # We need to handle the train and val dataloaders differently.
-        # For training, the unlabelled data is returned while for validation,
-        # the unlabelled data is just omitted.
         if self.training:
-            (x_lab, y), x_unl = batch
+            (x_lbl, y_lbl), x_unl = batch
         else:
-            x_lab, y = batch
-            x_unl = []
+            x_lbl, y_lbl = batch
+            x_unl = None
 
-        (x_lab_trans, y_trans), x_unl_trans = preprocess(
-            x_lab=x_lab,
-            y_lab=y,
-            x_unl=x_unl,
+        return preprocess(
+            x_lab=x_lbl,
+            y_lab=y_lbl,
             x_scaler=self.x_scaler,
             y_encoder=self.y_encoder,
+            x_unl=x_unl,
         )
-        if self.training:
-            return (x_lab_trans, y_trans), x_unl_trans
-        else:
-            return x_lab_trans, y_trans

--- a/src/frdc/train/mixmatch_module.py
+++ b/src/frdc/train/mixmatch_module.py
@@ -257,8 +257,8 @@ class MixMatchModule(LightningModule):
             x_unl = None
 
         return preprocess(
-            x_lab=x_lbl,
-            y_lab=y_lbl,
+            x_lbl=x_lbl,
+            y_lbl=y_lbl,
             x_scaler=self.x_scaler,
             y_encoder=self.y_encoder,
             x_unl=x_unl,

--- a/src/frdc/train/mixmatch_module.py
+++ b/src/frdc/train/mixmatch_module.py
@@ -194,7 +194,7 @@ class MixMatchModule(LightningModule):
         self.update_ema()
 
     def validation_step(self, batch, batch_idx):
-        x, y = batch
+        (x, y), _x_unls = batch
         wandb.log({"val/y_lbl": wandb_hist(y, self.n_classes)})
         y_pred = self.ema_model(x)
         wandb.log(
@@ -214,7 +214,7 @@ class MixMatchModule(LightningModule):
         return loss
 
     def test_step(self, batch, batch_idx):
-        x, y = batch
+        (x, y), _x_unls = batch
         y_pred = self.ema_model(x)
         loss = F.cross_entropy(y_pred, y.long())
 
@@ -226,7 +226,7 @@ class MixMatchModule(LightningModule):
         return loss
 
     def predict_step(self, batch, *args, **kwargs) -> Any:
-        x, y = batch
+        (x, y), _x_unls = batch
         y_pred = self.ema_model(x)
         y_true_str = self.y_encoder.inverse_transform(
             y.cpu().numpy().reshape(-1, 1)

--- a/src/frdc/train/utils.py
+++ b/src/frdc/train/utils.py
@@ -53,8 +53,8 @@ def sharpen(y: torch.Tensor, temp: float) -> torch.Tensor:
 
 
 def preprocess(
-    x_lab: torch.Tensor,
-    y_lab: torch.Tensor,
+    x_lbl: torch.Tensor,
+    y_lbl: torch.Tensor,
     x_scaler: StandardScaler,
     y_encoder: OrdinalEncoder,
     x_unl: list[torch.Tensor] = None,
@@ -69,8 +69,8 @@ def preprocess(
         This happens due to unlabelled being a list of tensors.
 
     Args:
-        x_lab: The data to preprocess.
-        y_lab: The labels to preprocess.
+        x_lbl: The data to preprocess.
+        y_lbl: The labels to preprocess.
         x_scaler: The StandardScaler to use.
         y_encoder: The OrdinalEncoder to use.
 
@@ -80,8 +80,8 @@ def preprocess(
 
     x_unl = [] if x_unl is None else x_unl
 
-    x_lab_trans = x_standard_scale(x_scaler, x_lab)
-    y_trans = y_encode(y_encoder, y_lab)
+    x_lbl_trans = x_standard_scale(x_scaler, x_lbl)
+    y_trans = y_encode(y_encoder, y_lbl)
     x_unl_trans = fn_recursive(
         x_unl,
         fn=lambda x: x_standard_scale(x_scaler, x),
@@ -93,8 +93,8 @@ def preprocess(
     #   Ordinal Encoders can return a np.nan if the value is not in the
     #   categories. We will remove that from the batch.
     nan = ~torch.isnan(y_trans)
-    x_lab_trans = x_lab_trans[nan]
-    x_lab_trans = torch.nan_to_num(x_lab_trans)
+    x_lbl_trans = x_lbl_trans[nan]
+    x_lbl_trans = torch.nan_to_num(x_lbl_trans)
     x_unl_trans = fn_recursive(
         x_unl_trans,
         fn=lambda x: torch.nan_to_num(x[nan]),
@@ -103,7 +103,7 @@ def preprocess(
     )
     y_trans = y_trans[nan]
 
-    return (x_lab_trans, y_trans.long()), x_unl_trans
+    return (x_lbl_trans, y_trans.long()), x_unl_trans
 
 
 def x_standard_scale(

--- a/src/frdc/train/utils.py
+++ b/src/frdc/train/utils.py
@@ -146,7 +146,7 @@ def y_encode(y_encoder: OrdinalEncoder, y: torch.Tensor) -> torch.Tensor:
         y: The labels to encode.
     """
     return torch.from_numpy(
-        y_encoder.transform(np.array(y).reshape(-1, 1)).squeeze()
+        y_encoder.transform(np.array(y).reshape(-1, 1))[..., 0]
     )
 
 


### PR DESCRIPTION
# Major Changes
For `on_before_batch_transfer` in the modules, it **return different signatures for training and validation**
This change makes it such that it returns the same signature. The callers should handle this difference in signature by
having unused variables. This makes it a little cleaner as we're directing the responsibility to the children